### PR TITLE
js: Fix redirecting for links to methods and properties

### DIFF
--- a/static/scripts/redirect.js
+++ b/static/scripts/redirect.js
@@ -12,8 +12,23 @@
 		const match = hash.match( regex );
 
 		if ( match ) {
-			const extracted = match[ 1 ];
-			window.location.href = new URL( `${ extracted }.html`, base );
+			let targetHash = '';
+			const extracted = match[ 1 ].replace(
+				/(\.([^-]+))-(?:static-(?:method|property)-(.+)|(?:method|property)-(.+)|.+)$/g,
+				( postfix, keep, className, staticName, instanceName ) => {
+					if ( staticName ) {
+						targetHash = `#.${ staticName }`;
+					} else if ( instanceName ) {
+						if ( instanceName === 'constructor' ) {
+							targetHash = `#${ className }`;
+						} else {
+							targetHash = `#${ instanceName }`;
+						}
+					}
+					return keep;
+				}
+			);
+			window.location.href = new URL( `${ extracted }.html${ targetHash }`, base );
 		}
 	}
 }


### PR DESCRIPTION
Prior to this change, old links to methods and properties redirected to a 404 page (e.g. https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-clone; more examples at T352320#9776297). With this change, the user is redirected correctly for both static and instance methods and properties. Other possible postfixes starting with "-" are removed (at least the user will be redirected to an existing page and not 404).

Bug: T352320